### PR TITLE
Use the DB_HOST parameter on wp-config to run mysqldump database & disable COMPRESSION for HomeDirectory & limit backup to certain sub-directories and files

### DIFF
--- a/WordPressBackup.sh
+++ b/WordPressBackup.sh
@@ -65,6 +65,19 @@ for backupprofile in $profile ; do
 			db_host=$(grep DB_HOST "${wp_config}" | cut -f4 -d"'")
 			table_prefix=$(grep table_prefix "${wp_config}" | cut -f2 -d"'")
 
+			# Which files & sub-directories to backup of the root directory
+			if [ "${file_list}" = "" ]; then
+				file_list_bckp =  ${wp_root}
+			else
+				files=(${file_list})
+				file_list_absolute=""
+				for i in "${!files[@]}"
+				do
+				        file_list_absolute="${file_list_absolute} ${wp_root}/${files[i]}";
+				done
+				file_list_bckp=${file_list_absolute}
+			fi
+
 			# Creates a Backup Directory if one does not exist.
 			mkdir -p ${backup_location}/${user}/${wp_domain}/
 
@@ -73,7 +86,7 @@ for backupprofile in $profile ; do
 
 			# MySQL Takes a Dump and compress the Home Directory
 			mysqldump -u ${db_user} --host ${db_host}  -p${db_pass} ${db_name} | gzip > ./${backupname}-DB.sql.gz &&
-			tar zcPf ./${backupname}-FILES.tar.gz ${wp_root}
+			tar zcPf ./${backupname}-FILES.tar.gz ${file_list_bckp}
 
 			# Compresses the MySQL Dump and the Home Directory
 			tar zcPf ./${wp_domain}-${backupname}.tar.gz ./${backupname}-FILES.tar.gz ./${backupname}-DB.sql.gz

--- a/WordPressBackup.sh
+++ b/WordPressBackup.sh
@@ -62,6 +62,7 @@ for backupprofile in $profile ; do
 			db_name=$(grep DB_NAME "${wp_config}" | cut -f4 -d"'")
 			db_user=$(grep DB_USER "${wp_config}" | cut -f4 -d"'")
 			db_pass=$(grep DB_PASSWORD "${wp_config}" | cut -f4 -d"'")
+			db_host=$(grep DB_HOST "${wp_config}" | cut -f4 -d"'")
 			table_prefix=$(grep table_prefix "${wp_config}" | cut -f2 -d"'")
 
 			# Creates a Backup Directory if one does not exist.
@@ -71,7 +72,7 @@ for backupprofile in $profile ; do
 			cd ${backup_location}/${user}/${wp_domain}
 
 			# MySQL Takes a Dump and compress the Home Directory
-			mysqldump -u ${db_user} -p${db_pass} ${db_name} | gzip > ./${backupname}-DB.sql.gz &&
+			mysqldump -u ${db_user} --host ${db_host}  -p${db_pass} ${db_name} | gzip > ./${backupname}-DB.sql.gz &&
 			tar zcPf ./${backupname}-FILES.tar.gz ${wp_root}
 
 			# Compresses the MySQL Dump and the Home Directory

--- a/backup.profile.example
+++ b/backup.profile.example
@@ -17,6 +17,10 @@ wp_root=/home/admin/example.com/public_html
 # Example (only user content): wp-content wp-config*
 file_list="wp-* favicon.ico index*"
 
+# Optional: if your files & directories to be backed up are too bigger in size, you can set this to false
+# and then that backup will not be compressed and the the daily backup were composed by 2 files (SQL.GZ for DB and TAR for files&dirs)
+compressed_tar_file=false
+
 # Backup location
 backup_location=/backups
 

--- a/backup.profile.example
+++ b/backup.profile.example
@@ -12,6 +12,11 @@ wp_domain=example.com
 # Directory that WordPress is installed at
 wp_root=/home/admin/example.com/public_html
 
+# Optional: backup only these files & directories to be included
+# Example (all WP): wp-* favicon.ico index*
+# Example (only user content): wp-content wp-config*
+file_list="wp-* favicon.ico index*"
+
 # Backup location
 backup_location=/backups
 


### PR DESCRIPTION
Hi. Thanks for this extremely simple and useful script. I modified 2 lines on the script to be able to use the DB_HOST parameter defined on wp-config.php 😉

Indeed, i also needed to add some way to define a list of ONLY-INCLUDED sub-directories and files when backing up the Home directory. Because my subdomains are stored on sub-directories of the main domain name (is a default setting on my hosting) so... i need a way to exclude such directories when backing up the main WP site. Well, even is usual to have another directories not used by WP... so i would like to define a list of EXCLUDED directories.

Also, one of my WP sites has a Home Directory VERY HEAVY (about 7.5Gb of photos and videos) and then i choosed to add the option in the profile of NOT-USE COMPRESSED-TAR files. When you set this parameter then the result are 2 files per daily backup of a site: 1) db.sql.gz + 2) FILES.tar

The save of time is almost 10 times comparing to use compressed TAR files! And the size of the backup is not more bigger than 20-35% So at least in my case i prefer be faster and heavier than slower and smaller.

Cheers!
Sergi